### PR TITLE
feat: add option for mixed precision dtype to enable running on cpus

### DIFF
--- a/roma/models/model_zoo/__init__.py
+++ b/roma/models/model_zoo/__init__.py
@@ -10,7 +10,7 @@ weight_urls = {
     "dinov2": "https://dl.fbaipublicfiles.com/dinov2/dinov2_vitl14/dinov2_vitl14_pretrain.pth", #hopefully this doesnt change :D
 }
 
-def roma_outdoor(device, weights=None, dinov2_weights=None, coarse_res: Union[int,tuple[int,int]] = 560, upsample_res: Union[int,tuple[int,int]] = 864):
+def roma_outdoor(device, weights=None, dinov2_weights=None, coarse_res: Union[int,tuple[int,int]] = 560, upsample_res: Union[int,tuple[int,int]] = 864, amp_dtype: torch.dtype = torch.float16):
     if isinstance(coarse_res, int):
         coarse_res = (coarse_res, coarse_res)
     if isinstance(upsample_res, int):    
@@ -26,12 +26,12 @@ def roma_outdoor(device, weights=None, dinov2_weights=None, coarse_res: Union[in
         dinov2_weights = torch.hub.load_state_dict_from_url(weight_urls["dinov2"],
                                                      map_location=device)
     model = roma_model(resolution=coarse_res, upsample_preds=True,
-               weights=weights,dinov2_weights = dinov2_weights,device=device)
+               weights=weights,dinov2_weights = dinov2_weights,device=device, amp_dtype=amp_dtype)
     model.upsample_res = upsample_res
     print(f"Using coarse resolution {coarse_res}, and upsample res {model.upsample_res}")
     return model
 
-def roma_indoor(device, weights=None, dinov2_weights=None, coarse_res: Union[int,tuple[int,int]] = 560, upsample_res: Union[int,tuple[int,int]] = 864):
+def roma_indoor(device, weights=None, dinov2_weights=None, coarse_res: Union[int,tuple[int,int]] = 560, upsample_res: Union[int,tuple[int,int]] = 864, amp_dtype: torch.dtype = torch.float16):
     if isinstance(coarse_res, int):
         coarse_res = (coarse_res, coarse_res)
     if isinstance(upsample_res, int):    
@@ -47,7 +47,7 @@ def roma_indoor(device, weights=None, dinov2_weights=None, coarse_res: Union[int
         dinov2_weights = torch.hub.load_state_dict_from_url(weight_urls["dinov2"],
                                                      map_location=device)
     model = roma_model(resolution=coarse_res, upsample_preds=True,
-               weights=weights,dinov2_weights = dinov2_weights,device=device)
+               weights=weights,dinov2_weights = dinov2_weights,device=device, amp_dtype=amp_dtype)
     model.upsample_res = upsample_res
     print(f"Using coarse resolution {coarse_res}, and upsample res {model.upsample_res}")
     return model

--- a/roma/models/model_zoo/roma_models.py
+++ b/roma/models/model_zoo/roma_models.py
@@ -1,10 +1,11 @@
 import warnings
 import torch.nn as nn
+import torch
 from roma.models.matcher import *
 from roma.models.transformer import Block, TransformerDecoder, MemEffAttention
 from roma.models.encoders import *
 
-def roma_model(resolution, upsample_preds, device = None, weights=None, dinov2_weights=None, **kwargs):
+def roma_model(resolution, upsample_preds, device = None, weights=None, dinov2_weights=None, amp_dtype: torch.dtype=torch.float16, **kwargs):
     # roma weights and dinov2 weights are loaded seperately, as dinov2 weights are not parameters
     #torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul TODO: these probably ruin stuff, should be careful
     #torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
@@ -146,7 +147,8 @@ def roma_model(resolution, upsample_preds, device = None, weights=None, dinov2_w
             amp = True),
         amp = True,
         use_vgg = True,
-        dinov2_weights = dinov2_weights
+        dinov2_weights = dinov2_weights,
+        amp_dtype=amp_dtype,
     )
     h,w = resolution
     symmetric = True


### PR DESCRIPTION
Solves https://github.com/Parskatt/RoMa/issues/26

Changes:
- Add optional parameter `amp_dtype`

One can now run RoMa on cpu by specifying `amp_dtype=torch.float32` like so:

```python
roma_model = roma_outdoor(device=device, amp_dtype=torch.float32)
```
