### PR TITLE
Fix autocast on cpu; fix weight download path

### DIFF
--- a/experiments/eval_tiny_roma_v1_outdoor.py
+++ b/experiments/eval_tiny_roma_v1_outdoor.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     from romatch import tiny_roma_v1_outdoor
 
     experiment_name = Path(__file__).stem
-    device = 'cuda'
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = tiny_roma_v1_outdoor(device)
     #test_mega1500_poselib(model, experiment_name)
     test_mega_8_scenes_poselib(model, experiment_name)

--- a/experiments/train_tiny_roma_v1_outdoor.py
+++ b/experiments/train_tiny_roma_v1_outdoor.py
@@ -491,7 +491,7 @@ if __name__ == "__main__":
         train(args)
 
     experiment_name = "tiny_roma_v1_outdoor"#Path(__file__).stem
-    device = 'cuda'
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = XFeatModel(freeze_xfeat=False, exact_softmax=False).to(device)
     model.load_state_dict(torch.load(f"{experiment_name}.pth"))
     test_mega1500_poselib(model, experiment_name)

--- a/romatch/models/encoders.py
+++ b/romatch/models/encoders.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.models as tvm
 import gc
+from romatch.utils.utils import get_autocast_params
 
 
 class ResNet50(nn.Module):
@@ -28,7 +29,8 @@ class ResNet50(nn.Module):
         self.amp_dtype = amp_dtype
 
     def forward(self, x, **kwargs):
-        with torch.autocast("cuda", enabled=self.amp, dtype = self.amp_dtype):
+        autocast_device, autocast_enabled, autocast_dtype = get_autocast_params(x.device, self.amp, self.amp_dtype)
+        with torch.autocast(autocast_device, enabled=autocast_enabled, dtype = autocast_dtype):
             net = self.net
             feats = {1:x}
             x = net.conv1(x)
@@ -64,7 +66,8 @@ class VGG19(nn.Module):
         self.amp_dtype = amp_dtype
 
     def forward(self, x, **kwargs):
-        with torch.autocast("cuda", enabled=self.amp, dtype = self.amp_dtype):
+        autocast_device, autocast_enabled, autocast_dtype = get_autocast_params(x.device, self.amp, self.amp_dtype)
+        with torch.autocast(device_type=autocast_device, enabled=autocast_enabled, dtype = autocast_dtype):
             feats = {}
             scale = 1
             for layer in self.layers:

--- a/romatch/models/model_zoo/__init__.py
+++ b/romatch/models/model_zoo/__init__.py
@@ -4,11 +4,11 @@ from .roma_models import roma_model, tiny_roma_v1_model
 
 weight_urls = {
     "romatch": {
-        "outdoor": "https://github.com/Parskatt/storage/releases/download/romatch/roma_outdoor.pth",
-        "indoor": "https://github.com/Parskatt/storage/releases/download/romatch/roma_indoor.pth",
+        "outdoor": "https://github.com/Parskatt/storage/releases/download/roma/roma_outdoor.pth",
+        "indoor": "https://github.com/Parskatt/storage/releases/download/roma/roma_indoor.pth",
     },
     "tiny_roma_v1": {
-        "outdoor": "https://github.com/Parskatt/storage/releases/download/romatch/tiny_roma_v1_outdoor.pth",
+        "outdoor": "https://github.com/Parskatt/storage/releases/download/roma/tiny_roma_v1_outdoor.pth",
     },
     "dinov2": "https://dl.fbaipublicfiles.com/dinov2/dinov2_vitl14/dinov2_vitl14_pretrain.pth", #hopefully this doesnt change :D
 }
@@ -32,6 +32,9 @@ def roma_outdoor(device, weights=None, dinov2_weights=None, coarse_res: Union[in
         coarse_res = (coarse_res, coarse_res)
     if isinstance(upsample_res, int):    
         upsample_res = (upsample_res, upsample_res)
+
+    if str(device) == 'cpu':
+        amp_dtype = torch.float32
 
     assert coarse_res[0] % 14 == 0, "Needs to be multiple of 14 for backbone"
     assert coarse_res[1] % 14 == 0, "Needs to be multiple of 14 for backbone"

--- a/romatch/models/transformer/__init__.py
+++ b/romatch/models/transformer/__init__.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from romatch.utils.utils import get_grid
+from romatch.utils.utils import get_grid, get_autocast_params
 from .layers.block import Block
 from .layers.attention import MemEffAttention
 from .dinov2 import vit_large
@@ -28,7 +28,8 @@ class TransformerDecoder(nn.Module):
         return self._scales.copy()
 
     def forward(self, gp_posterior, features, old_stuff, new_scale):
-        with torch.autocast("cuda", dtype=self.amp_dtype, enabled=self.amp):
+        autocast_device, autocast_enabled, autocast_dtype = get_autocast_params(gp_posterior.device, enabled=self.amp, dtype=self.amp_dtype)
+        with torch.autocast(autocast_device, enabled=autocast_enabled, dtype = autocast_dtype):
             B,C,H,W = gp_posterior.shape
             x = torch.cat((gp_posterior, features), dim = 1)
             B,C,H,W = x.shape

--- a/romatch/utils/utils.py
+++ b/romatch/utils/utils.py
@@ -623,3 +623,16 @@ def get_grid(b, h, w, device):
     )
     grid = torch.stack((grid[2], grid[1]), dim=-1).reshape(b, h, w, 2)
     return grid
+
+
+def get_autocast_params(device=None, enabled=False, dtype=None):
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    if 'cuda' in str(device):
+        out_dtype = dtype
+        enabled = True
+    else:
+        out_dtype = torch.bfloat16
+        enabled = False
+    return str(device), enabled, out_dtype


### PR DESCRIPTION
Fixes #47.

 Allows for interence on cpu. Did not have GPU to test on, but should not affect GPU ops as the new fn is just a passthrough in the case of cuda devices. 

Also fixed weights download path, which should still be /roma rather than /romatch. 

Recommended to verify works on GPU as well prior to merge. 