### PR TITLE
only fused-local-corr for linux and make matching params visible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.9"
 dependencies = [
     "albumentations",
     "einops",
-    "fused-local-corr>=0.2.2",
+    "fused-local-corr>=0.2.2 ; sys_platform == 'linux'",
     "h5py",
     "kornia",
     "loguru",

--- a/romatch/utils/local_correlation.py
+++ b/romatch/utils/local_correlation.py
@@ -1,7 +1,6 @@
 from typing import Literal
 import torch
 import torch.nn.functional as F
-import local_corr
 
 
 def local_corr_wrapper(
@@ -20,6 +19,7 @@ def local_corr_wrapper(
     sample_mode: Literal["bilinear", "nearest"] = "bilinear",
     dtype=torch.float32,
 ):
+    import local_corr
     assert padding_mode == "zeros"
     warp = (coords[..., None, :] + local_window[:, None, None]).reshape(B, h * w, K, 2)
     corr = (

--- a/tests/test_mega1500.py
+++ b/tests/test_mega1500.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     # gotten on 3.12 env with torch 2.8.0
     reference_scores = [0.6271474434923545, 0.7673889435429945, 0.8642099162282599] # slightly worse.
     # old_reference_scores = [0.6235757679569996, 0.7648007367330985, 0.8630483724961098]
-    assert np.isclose(results[0], reference_scores[0], atol=3e-1 / 100)
-    assert np.isclose(results[1], reference_scores[1], atol=2e-1 / 100)
-    assert np.isclose(results[2], reference_scores[2], atol=1e-1 / 100)
+    assert np.isclose(results["auc_5"], reference_scores[0], atol=3e-1 / 100)
+    assert np.isclose(results["auc_10"], reference_scores[1], atol=2e-1 / 100)
+    assert np.isclose(results["auc_20"], reference_scores[2], atol=1e-1 / 100)
     

--- a/uv.lock
+++ b/uv.lock
@@ -542,9 +542,9 @@ name = "fused-local-corr"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "torch" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+    { name = "torch", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/72/7fd886f0fcd4b66d10c341d78a960adfab0b807ff1e72998bee123ebcb7a/fused_local_corr-0.2.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:573a766ae4b108491a085454f6044970b36e9e66259b23a0413ee2d7befb018a", size = 254718, upload-time = "2025-09-10T21:22:30.681Z" },
@@ -1930,7 +1930,7 @@ source = { editable = "." }
 dependencies = [
     { name = "albumentations" },
     { name = "einops" },
-    { name = "fused-local-corr" },
+    { name = "fused-local-corr", marker = "sys_platform == 'linux'" },
     { name = "h5py" },
     { name = "kornia" },
     { name = "loguru" },
@@ -1954,7 +1954,7 @@ dev = [
 requires-dist = [
     { name = "albumentations" },
     { name = "einops" },
-    { name = "fused-local-corr", specifier = ">=0.2.2" },
+    { name = "fused-local-corr", marker = "sys_platform == 'linux'", specifier = ">=0.2.2" },
     { name = "h5py" },
     { name = "kornia" },
     { name = "loguru" },


### PR DESCRIPTION
1. Only use the fused kernel on linux, so make dep conditional on platform.
2. Also makes a bunch of params of the matcher visible in the api.

Should fix #121 