### PR TITLE
freshen up the hpatches eval

### DIFF
--- a/experiments/eval_roma_outdoor.py
+++ b/experiments/eval_roma_outdoor.py
@@ -53,5 +53,6 @@ if __name__ == "__main__":
     model = roma_outdoor(device = device, coarse_res = 672, upsample_res = 1344)
     experiment_name = "roma_latest"
     test_mega1500(model, experiment_name)
+    test_hpatches(model, experiment_name)
     #test_mega1500_poselib(model, experiment_name)
     

--- a/romatch/benchmarks/hpatches_sequences_homog_benchmark.py
+++ b/romatch/benchmarks/hpatches_sequences_homog_benchmark.py
@@ -1,6 +1,6 @@
 from PIL import Image
 import numpy as np
-
+import torch
 import os
 
 from tqdm import tqdm
@@ -32,7 +32,7 @@ class HpatchesHomogBenchmark:
     def convert_coordinates(self, im_A_coords, im_A_to_im_B, wq, hq, wsup, hsup):
         offset = 0.5  # Hpatches assumes that the center of the top-left pixel is at [0,0] (I think)
         im_A_coords = (
-            np.stack(
+            torch.stack(
                 (
                     wq * (im_A_coords[..., 0] + 1) / 2,
                     hq * (im_A_coords[..., 1] + 1) / 2,
@@ -42,7 +42,7 @@ class HpatchesHomogBenchmark:
             - offset
         )
         im_A_to_im_B = (
-            np.stack(
+            torch.stack(
                 (
                     wsup * (im_A_to_im_B[..., 0] + 1) / 2,
                     hsup * (im_A_to_im_B[..., 1] + 1) / 2,
@@ -78,8 +78,8 @@ class HpatchesHomogBenchmark:
                 )
                 try:
                     H_pred, inliers = cv2.findHomography(
-                        pos_a,
-                        pos_b,
+                        pos_a.cpu().numpy(),
+                        pos_b.cpu().numpy(),
                         method = cv2.RANSAC,
                         confidence = 0.99999,
                         ransacReprojThreshold = 3 * min(w2, h2) / 480,

--- a/uv.lock
+++ b/uv.lock
@@ -1925,7 +1925,7 @@ wheels = [
 
 [[package]]
 name = "romatch"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "albumentations" },


### PR DESCRIPTION
Running 
```
uv run experiments/eval_roma_outdoor.py
```
Gives reproduced results:
```
0 =0.45690579606209075
1 =0.6369895726401528
2 =0.7258865738276127
3 =0.779550519348575
4 =0.8143447600109477
5 =0.8386216326569257
6 =0.8566230317804007
7 =0.8707689503051904
8 =0.8821527645786703
9 =0.8915236950173551
```

Corresponds to `72.6` AUC@3px.
